### PR TITLE
Use 'vim.fn.jobstart()' for android emulator

### DIFF
--- a/lua/simulators/android_emulator.lua
+++ b/lua/simulators/android_emulator.lua
@@ -21,7 +21,15 @@ end
 
 M.run = function(name)
   local cmd = "emulator -avd " .. name
-  vim.fn.system(cmd)
+  local job_id = vim.fn.jobstart(cmd, { -- using jobstart here as .system blocks my input
+      detach = true,
+  })
+
+  if job_id <= 0 then
+      vim.notify("Failed to start " .. name, vim.log.levels.ERROR)
+  else
+      vim.notify("Started " .. name, vim.log.levels.INFO)
+  end
 end
 
 return M


### PR DESCRIPTION
'vim.fn.system()' was causing my nvim instance to not react/redraw to any inputs until I closed the emulator instance again. Using 'jobstart' gets rid of that problem and makes sure the emulator is detached from the current buffer.